### PR TITLE
Fix  a couple of links in the README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Minecraft Forge Modpack designed as a comfy but adventurous modpack.
 
 **Download Prism** - You can find the download link [here](https://prismlauncher.org/download/).
 
-**Download latest modpack version** - You can find the latest release [here](https://github.com/KittenzExe/YarnModpack/releases).
+**Download latest modpack version** - You can find the latest release [here](https://github.com/KittenzExe/YarnModpack/releases/latest).
 
 **Setup** - Go to Add Instance, Import from zip, then select either the .zip or .mrpack file.
 
@@ -34,11 +34,11 @@ A Minecraft Forge Modpack designed as a comfy but adventurous modpack.
 
 ### 🚀 Other Launchers
 
-**Download latest modpack version** - You can find the latest release [here](https://github.com/KittenzExe/YarnModpack/releases).
+**Download latest modpack version** - You can find the latest release [here](https://github.com/KittenzExe/YarnModpack/releases/latest).
 
 **Setup** - Select either the .zip or .mrpack file and import that into your prefered Minecraft Launcher
 
-**Updating** - If your launcher doesn't have an option to use packwiz, you can download the [latest release](https://github.com/KittenzExe/YarnModpack/releases). (Weekly updates)
+**Updating** - If your launcher doesn't have an option to use packwiz, you can download the [latest release](https://github.com/KittenzExe/YarnModpack/releases/latest). (Weekly updates)
 
 ## 🧵 Have fun!
 

--- a/index.toml
+++ b/index.toml
@@ -154,7 +154,7 @@ metafile = true
 
 [[files]]
 file = "mods/collective.pw.toml"
-hash = "bfa6f98bbf994fc1e3a7d2dc9ccbda3f4089b8a57a82baf0f6d928fa369caadc"
+hash = "5333619ce0f7e191d409fac6cd1c5981b15fd9baee160114e4a5010d9b44761d"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -399,7 +399,7 @@ metafile = true
 
 [[files]]
 file = "mods/forge-cit.pw.toml"
-hash = "f0f999293f442227eab70ab867bf14f1ed5c7f2ffda3d2e984a1e8e4e07daa24"
+hash = "aa80f559061dc262eeb6c0652bbc2edeb8372d5e17969e45e8e6e8bd9799ec12"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -184,7 +184,7 @@ metafile = true
 
 [[files]]
 file = "mods/copycats.pw.toml"
-hash = "a6a95c94b13bf9ab819ef5a9592dd41e0faef5cddbcaa08a0333c1261b7073fb"
+hash = "46adefd7fdff6a79a57d79a47073d55a28961be55408cebe7dbe16b2cadb9111"
 metafile = true
 
 [[files]]
@@ -419,7 +419,7 @@ metafile = true
 
 [[files]]
 file = "mods/iceberg.pw.toml"
-hash = "d0d383d4ff24fd6a4c5a9319806b0c99da9d0120fa14719911596eb39abc6f20"
+hash = "c2d0731f0a5f41ee581adcf4a4898b142dc8fb5806883225f82554388b3db37f"
 metafile = true
 
 [[files]]
@@ -444,7 +444,7 @@ metafile = true
 
 [[files]]
 file = "mods/item-highlighter.pw.toml"
-hash = "25a898a7d5ea660c4104734fb18c33de91d465f0acf518a0f5df18b20f8385de"
+hash = "77ede7a29d0bc2c7dbccca89c48bfe2c42d595fa495bce22f31fbbf2a4e9086c"
 metafile = true
 
 [[files]]
@@ -619,7 +619,7 @@ metafile = true
 
 [[files]]
 file = "mods/mystical-agriculture.pw.toml"
-hash = "36d42c7b64e8ebf304294b73eecd9717beca9437bf7af8b3b985df63ccd8a315"
+hash = "72e81f1905a3a6f7fb8beeb0e0e7010c8ab55dd6733a07d6e2e26d6f920d1852"
 metafile = true
 
 [[files]]

--- a/mods/copycats.pw.toml
+++ b/mods/copycats.pw.toml
@@ -1,13 +1,13 @@
 name = "Create: Copycats+"
-filename = "copycats-1.1.0-mc1.20.1-all.jar"
+filename = "Copycats-forge.1.20.1-1.2.0.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/UT2M39wf/versions/KaWzxkbC/copycats-1.1.0-mc1.20.1-all.jar"
+url = "https://cdn.modrinth.com/data/UT2M39wf/versions/L3l4jW7j/Copycats-forge.1.20.1-1.2.0.jar"
 hash-format = "sha1"
-hash = "abccd5b5b9702a42a2d897daaf614c4a8140969f"
+hash = "6892d9b7bdbc456056512ff0a3f01cdb181d0a8d"
 
 [update]
 [update.modrinth]
 mod-id = "UT2M39wf"
-version = "KaWzxkbC"
+version = "L3l4jW7j"

--- a/mods/forge-cit.pw.toml
+++ b/mods/forge-cit.pw.toml
@@ -1,6 +1,6 @@
 name = "Forge CIT"
 filename = "citresewn-1.20.1-5.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/iceberg.pw.toml
+++ b/mods/iceberg.pw.toml
@@ -1,6 +1,6 @@
 name = "Iceberg"
 filename = "Iceberg-1.20.1-forge-1.1.21.jar"
-side = "client"
+side = "both"
 
 [download]
 url = "https://cdn.modrinth.com/data/5faXoLqX/versions/boNnPeth/Iceberg-1.20.1-forge-1.1.21.jar"

--- a/mods/item-highlighter.pw.toml
+++ b/mods/item-highlighter.pw.toml
@@ -1,6 +1,6 @@
 name = "Item Highlighter [Forge]"
 filename = "Highlighter-1.20.1-forge-1.1.9.jar"
-side = "both"
+side = "client"
 
 [download]
 hash-format = "sha1"

--- a/mods/mystical-agriculture.pw.toml
+++ b/mods/mystical-agriculture.pw.toml
@@ -1,13 +1,13 @@
 name = "Mystical Agriculture"
-filename = "MysticalAgriculture-1.20.1-7.0.9.jar"
+filename = "MysticalAgriculture-1.20.1-7.0.10.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/C95ReXie/versions/yTuKnzVy/MysticalAgriculture-1.20.1-7.0.9.jar"
+url = "https://cdn.modrinth.com/data/C95ReXie/versions/cRMgDSq5/MysticalAgriculture-1.20.1-7.0.10.jar"
 hash-format = "sha1"
-hash = "34afd98a59d0f376a8df0f618bd782382815d290"
+hash = "ab4631365a0d5983ac9cc575653bdc5338a248f0"
 
 [update]
 [update.modrinth]
 mod-id = "C95ReXie"
-version = "yTuKnzVy"
+version = "cRMgDSq5"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "65e15f05be745e47d2ab47f6308958ea4726ee05c9f8849790a2184cfff2e6b3"
+hash = "59fb3d98979b2df3220c5202bf58db2d3e3bc7733764db2c27bae663ca7c6fcd"
 
 [versions]
 minecraft = "1.20.1"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "d9e47e8a3d138e34e8f7e068442ea5e100449123e8a88b243a36937e3aff313f"
+hash = "1c596ca89602a6ccfb4c3e080ddf57ac573ac612506ad16b369f014688f4523c"
 
 [versions]
 minecraft = "1.20.1"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "59fb3d98979b2df3220c5202bf58db2d3e3bc7733764db2c27bae663ca7c6fcd"
+hash = "d9e47e8a3d138e34e8f7e068442ea5e100449123e8a88b243a36937e3aff313f"
 
 [versions]
 minecraft = "1.20.1"


### PR DESCRIPTION
Made the release links point to https://github.com/KittenzExe/YarnModpack/releases/latest instead of https://github.com/KittenzExe/YarnModpack/releases